### PR TITLE
Remove PYC_Add and PYC_Sub in favor of PyNumber_Add/Sub

### DIFF
--- a/libpyc.c
+++ b/libpyc.c
@@ -1,36 +1,9 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
-inline PyObject* PYC_Add(PyObject* l, PyObject* r) {
-  // TODO: allow __add__ override
-
-  // Includes ints and bools
-  if (PyLong_Check(l) && PyLong_Check(r)) {
-    return PyNumber_Add(l, r);
-  }
-
-  // TODO: handle str, etc.
-
-  // TODO: throw exception
-  return NULL;
-}
-
-inline PyObject* PYC_Sub(PyObject* l, PyObject* r) {
-  // TODO: allow __add__ override
-
-  // Includes ints and bools
-  if (PyLong_Check(l) && PyLong_Check(r)) {
-    return PyNumber_Subtract(l, r);
-  }
-
-  // TODO: handle str, etc.
-
-  // TODO: throw exception
-  return NULL;
-}
-
 inline PyObject* PYC_Print(PyObject* o) {
   PyObject_Print(o, stdout, Py_PRINT_RAW);
   printf("\n");
+  Py_INCREF(Py_None);
   return Py_None;
 }

--- a/pyc/codegen.py
+++ b/pyc/codegen.py
@@ -22,9 +22,9 @@ def generate_bin_op(ctx: Context, binop: ast.BinOp) -> str:
     r = generate_expression(ctx, binop.right)
 
     if isinstance(binop.op, ast.Add):
-        ctx.body_write_statement(f"{result} = PYC_Add({l}, {r})")
+        ctx.body_write_statement(f"{result} = PyNumber_Add({l}, {r})")
     elif isinstance(binop.op, ast.Sub):
-        ctx.body_write_statement(f"{result} = PYC_Sub({l}, {r})")
+        ctx.body_write_statement(f"{result} = PyNumber_Subtract({l}, {r})")
     else:
         raise Exception(f"Unsupported binary operator: {type(binop.op)}")
 


### PR DESCRIPTION
These abstract functions are generic enough to handle anything that
defines an `__add__` function or equivalent slot. They also already handle
subclasses properly.